### PR TITLE
front: fix harmless cDU crash on Employers page

### DIFF
--- a/front/src/pages/actu/Employers.js
+++ b/front/src/pages/actu/Employers.js
@@ -203,6 +203,8 @@ export class Employers extends Component {
         this.setState({ currentDeclaration, isLoading: false })
 
         if (currentDeclaration.employers.length === 0) {
+          if (!previousDeclaration) return
+
           const relevantPreviousEmployers = previousDeclaration.employers.filter(
             (employer) => !employer.hasEndedThisMonth,
           )


### PR DESCRIPTION
Harmless because it caused logged error, but had the same effect as an empty return, which was what it was supposed to do