### PR TITLE
back: fix declaration confirmation document generation

### DIFF
--- a/back/lib/mailings/sendDeclarationConfirmationEmails.js
+++ b/back/lib/mailings/sendDeclarationConfirmationEmails.js
@@ -85,7 +85,7 @@ const generateDocument = (declaration) => {
   )
   cell.text(
     `-        ${
-      declaration.hasSickLeave ? 'Avoir' : 'Ne pas avoir'
+      declaration.hasMaternityLeave ? 'Avoir' : 'Ne pas avoir'
     } été en congé maternité`,
   )
   cell.text(


### PR DESCRIPTION
Mistakenly showed maternity leave when sick leaves were declared