### PR TITLE
front fix: detect earlier invalid user tokens for login redirection

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -128,15 +128,16 @@ class App extends Component {
 
         if (!user) return
 
+        if (!user.isTokenValid) {
+          window.location = '/api/login'
+          return
+        }
+
         this.setState({ user })
 
         window.Raven.setUserContext({
           id: user.id,
         })
-        if (!user.isTokenValid) {
-          window.location = '/api/login'
-          return
-        }
 
         return Promise.all([
           superagent


### PR DESCRIPTION
This avoids an error which appeared because user was in the app's state even though the token had expired