### PR TITLE
fix front dependencies

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -148,6 +148,7 @@
     "babel-jest": "^23.6.0",
     "eslint-config-react-app": "^3.0.5",
     "react-test-renderer": "^16.8.5",
+    "regenerator-runtime": "^0.13.2",
     "source-map-explorer": "^1.5.0",
     "storybook-host": "^5.0.0",
     "terser-webpack-plugin": "^1.1.0",

--- a/front/package.json
+++ b/front/package.json
@@ -113,7 +113,8 @@
       [
         "@babel/preset-env",
         {
-          "useBuiltIns": "entry"
+          "useBuiltIns": "entry",
+          "corejs": "2.6.0"
         }
       ]
     ],


### PR DESCRIPTION
* add missing regenerator-runtime for prod builds
* remove warning by setting babel-preset-env option corejs