### PR TITLE
back: add the ability to have a test email specified in the configuration

### DIFF
--- a/back/config/default.js
+++ b/back/config/default.js
@@ -15,6 +15,8 @@ module.exports = {
   shouldSendTransactionalEmails:
     process.env.SEND_TRANSACTIONAL_EMAILS === 'true',
   authorizeAllUsers: process.env.AUTHORIZE_ALL_USERS === 'true',
+  // fill in local-* config file with an email if ever needed to test emails out of prod env
+  testEmail: '',
   // The following 2 values should never be activated out of local development
   // they are only listed here as an information of their existence.
   bypassDeclarationDispatch: false,

--- a/back/lib/mailings/mailjet.js
+++ b/back/lib/mailings/mailjet.js
@@ -2,6 +2,7 @@ const NodeMailjet = require('node-mailjet')
 const { addDays, format } = require('date-fns')
 const superagent = require('superagent')
 const { get } = require('lodash')
+const config = require('config')
 
 const isProd = process.env.NODE_ENV === 'production'
 const LIST_ID = isProd ? 14703 : 10129294 // id of prod list / a test list with devs
@@ -19,8 +20,12 @@ const mailjet = NodeMailjet.connect(
 const sendMail = (opts) =>
   mailjet.post('send', { version: 'v3.1' }).request({
     // Mailjet *will* send e-mails out of prod if this line is removed
-    SandboxMode: process.env.NODE_ENV !== 'production',
+    SandboxMode: !isProd,
     ...opts,
+    Messages: opts.Messages.map((message) => ({
+      ...message,
+      To: isProd ? message.To : [{ Email: config.get('testEmail') }],
+    })),
   })
 
 const manageContact = ({ email, name, properties }) =>


### PR DESCRIPTION
@AlexandreCantin Comme on en parlait et suite au fiasco de ce matin, manière plus facile d'overrider les emails envoyés hors prod : Ajouter un `testEmail` à la config node, et si le mode Sandbox est désactivé, tous les mails partiront vers cette adresses