### PR TITLE
Acantin/quick fix

### DIFF
--- a/back/routes/admin.js
+++ b/back/routes/admin.js
@@ -72,6 +72,7 @@ router.get('/users', (req, res, next) => {
           'postalCode',
           'gender',
           'isAuthorized',
+          'peId',
         ]
 
         const json2csvParser = new Parser({ fields })

--- a/front/src/components/Actu/EmployerQuestion.js
+++ b/front/src/components/Actu/EmployerQuestion.js
@@ -186,7 +186,8 @@ export class EmployerQuestion extends Component {
         fullWidth={verticalLayout}
       />
     )
-    const workHoursTooltip = 'Déclarez les heures réellement travaillées'
+    const workHoursTooltip =
+      'Indiquez les heures qui seront inscrites sur votre fiche de paie'
 
     // Salary
     const salaryTextField = (

--- a/front/src/components/Generic/YesNoRadioGroup.js
+++ b/front/src/components/Generic/YesNoRadioGroup.js
@@ -60,8 +60,33 @@ export class YesNoRadioGroup extends Component {
       },
     })
 
-  renderRadioGroup() {
-    const { name, value } = this.props
+  render() {
+    const { name, value, yesTooltipContent } = this.props
+
+    const yesRadio = (
+      <StyledRadio
+        inputProps={{
+          'aria-describedby': `yes[${name}]`,
+        }}
+      />
+    )
+
+    const yesFormLabelAndRadio = (
+      <FirstFormControlLabel
+        value="yes"
+        control={
+          yesTooltipContent ? (
+            <TooltipOnFocus content={yesTooltipContent}>
+              {yesRadio}
+            </TooltipOnFocus>
+          ) : (
+            yesRadio
+          )
+        }
+        label="oui"
+        checked={value}
+      />
+    )
 
     return (
       <StyledRadioGroup
@@ -70,18 +95,7 @@ export class YesNoRadioGroup extends Component {
         value={getFormValue(value)}
         onChange={this.onChange}
       >
-        <FirstFormControlLabel
-          value="yes"
-          control={
-            <StyledRadio
-              inputProps={{
-                'aria-describedby': `yes[${name}]`,
-              }}
-            />
-          }
-          label="oui"
-          checked={value}
-        />
+        {yesFormLabelAndRadio}
 
         <SecondFormControlLabel
           value="no"
@@ -90,18 +104,6 @@ export class YesNoRadioGroup extends Component {
           checked={value === false}
         />
       </StyledRadioGroup>
-    )
-  }
-
-  render() {
-    const { yesTooltipContent } = this.props
-
-    return yesTooltipContent ? (
-      <TooltipOnFocus content={yesTooltipContent}>
-        {this.renderRadioGroup()}
-      </TooltipOnFocus>
-    ) : (
-      this.renderRadioGroup()
     )
   }
 }


### PR DESCRIPTION
- `la tooltip "mettez vos heures réellement travaillées" serai à remplacer par "indiquez les heures qui seront inscrites sur votre fiche de paie"` => Facile à faire

- `la tooltip "oubliez pas vos congés payés" se déclenche sur le mauvais bouton (devrai arriver si je coche "oui")`
Je suis moins emballé par la solution que j'ai mis en place... qui ressemble un peu trop à un anti-pattern. Je mets un contenu vide quand la réponse est `non` et la tooltip, du coup, ne s'affiche pas... Ou dit autrement, je demande l'affichage d'une tooltip vide qui s'auto-annule :disappointed_relieved: 

- `ajouter les peID dans les extract Zen`