### PR TITLE
Automatic user export list as CSV

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -62,6 +62,7 @@ typings/
 
 # custom
 uploads
+datalake
 extracts
 config/*production*.js
 config/local*.js

--- a/back/ecosystem.config.js
+++ b/back/ecosystem.config.js
@@ -6,14 +6,14 @@ const config = {
       watch:
         process.env.NODE_ENV === 'development' ||
         process.env.NODE_ENV === 'test',
-      ignore_watch: ['uploads'],
+      ignore_watch: ['uploads', 'datalake'],
     },
     {
       name: 'admin',
       script: 'bin/www',
       args: '--admin',
       watch: process.env.NODE_ENV === 'development',
-      ignore_watch: ['uploads'],
+      ignore_watch: ['uploads', 'datalake'],
     },
   ],
 }

--- a/back/jobs/utilities-agent.js
+++ b/back/jobs/utilities-agent.js
@@ -4,8 +4,12 @@ const winston = require('../lib/log')
 require('../lib/db') // setup db connection
 
 const cleanOldFiles = require('../lib/cleanOldFiles')
+const { saveUsersInCSV } = require('../lib/exportUserList')
 
 winston.info('Starting utilities agent')
 
 // Every sunday at 2:30
 job('0 30 2 * * 1', cleanOldFiles, null, true, 'Europe/Paris')
+
+// Every day at 6:30
+job('0 30 6 * * *', saveUsersInCSV, null, true, 'Europe/Paris')

--- a/back/lib/exportUserList.js
+++ b/back/lib/exportUserList.js
@@ -1,0 +1,69 @@
+const fs = require('fs')
+const { format, subDays } = require('date-fns')
+const { Parser } = require('json2csv')
+
+const winston = require('../lib/log')
+
+const User = require('../models/User')
+
+const EXPORT_DIR = '/home/back/datalake/versDatalake'
+const EXPORT_FILENAME_PATH = `${EXPORT_DIR}export_utilisateur.csv`
+const EXPORT_FIELDS = [
+  'firstName',
+  'lastName',
+  'email',
+  'postalCode',
+  'gender',
+  'isAuthorized',
+  'peId',
+]
+
+const renameFile = (from, to) =>
+  new Promise((resolve, reject) => {
+    fs.rename(from, to, (err) => {
+      if (err) return reject(err)
+      resolve()
+    })
+  })
+
+const saveUsersInCSV = async () => {
+  winston.info('Starting export users')
+
+  // Archive current file if exists
+  if (fs.existsSync(EXPORT_FILENAME_PATH)) {
+    const yesterdayDate = format(subDays(new Date(), 1), 'YYYY-MM-DD')
+
+    try {
+      await renameFile(
+        `${EXPORT_FILENAME_PATH}`,
+        `${EXPORT_DIR}${yesterdayDate}.csv`,
+      )
+    } catch (err) {
+      winston.error(err)
+      throw err
+    }
+  }
+
+  // Create file
+  fs.openSync(EXPORT_FILENAME_PATH, 'w')
+
+  // Extract and save in new file
+  return User.query().then((users) => {
+    const json2csvParser = new Parser({ fields: EXPORT_FIELDS })
+    const csvContent = json2csvParser.parse(users)
+
+    fs.writeFile(EXPORT_FILENAME_PATH, csvContent, function(err) {
+      if (err) {
+        winston.error(err)
+        throw err
+      }
+
+      winston.info('Finished export users')
+    })
+  })
+}
+
+module.exports = {
+  saveUsersInCSV,
+  EXPORT_FIELDS,
+}

--- a/back/routes/admin.js
+++ b/back/routes/admin.js
@@ -10,6 +10,7 @@ const { Parser } = require('json2csv')
 const winston = require('../lib/log')
 const { deleteUser } = require('../lib/user')
 const mailjet = require('../lib/mailings/mailjet')
+const { EXPORT_FIELDS } = require('../lib/exportUserList')
 
 const ActivityLog = require('../models/ActivityLog')
 const Declaration = require('../models/Declaration')
@@ -65,17 +66,7 @@ router.get('/users', (req, res, next) => {
     .where({ isAuthorized })
     .then((users) => {
       if ('csv' in req.query) {
-        const fields = [
-          'firstName',
-          'lastName',
-          'email',
-          'postalCode',
-          'gender',
-          'isAuthorized',
-          'peId',
-        ]
-
-        const json2csvParser = new Parser({ fields })
+        const json2csvParser = new Parser({ fields: EXPORT_FIELDS })
         const csv = json2csvParser.parse(users)
 
         res.set(

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,8 @@
-version: "2"
+version: '2'
 services:
   node:
+    volumes:
+      - '/mnt/datalake/vers_datalake/:/home/back/datalake/versDatalake'
     environment:
       - NODE_ENV=production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
-version: "2"
+version: '2'
 services:
   nginx:
     image: nginx
     restart: unless-stopped
     ports:
-      - "80:80"
-      - "443:443"
+      - '80:80'
+      - '443:443'
     volumes:
-      - "./nginx/production.conf:/etc/nginx/conf.d/default.conf"
-      - "./nginx/.htpasswd:/etc/nginx/.htpasswd"
-      - "./nginx/dhparam.pem:/etc/nginx/ssl/dhparam.pem"
-      - "./nginx/zen.crt:/etc/nginx/ssl/zen.crt"
-      - "./nginx/entrust-zen.pole-emploi.fr-key.pem:/etc/nginx/ssl/entrust-zen.pole-emploi.fr-key.pem"
-      - "./back/extracts:/home/extracts"
-      - "./front:/home/front"
-      - "./front-admin:/home/front-admin"
+      - './nginx/production.conf:/etc/nginx/conf.d/default.conf'
+      - './nginx/.htpasswd:/etc/nginx/.htpasswd'
+      - './nginx/dhparam.pem:/etc/nginx/ssl/dhparam.pem'
+      - './nginx/zen.crt:/etc/nginx/ssl/zen.crt'
+      - './nginx/entrust-zen.pole-emploi.fr-key.pem:/etc/nginx/ssl/entrust-zen.pole-emploi.fr-key.pem'
+      - './back/extracts:/home/extracts'
+      - './front:/home/front'
+      - './front-admin:/home/front-admin'
     environment:
       - TZ=Europe/Paris
     networks:
@@ -27,15 +27,15 @@ services:
       context: .
       dockerfile: dockerfile_back
     volumes:
-      - "./back:/home/back"
+      - './back:/home/back'
     expose:
-      - "8080"
-      - "8081"
+      - '8080'
+      - '8081'
     networks:
       actualisation_network:
         ipv4_address: 172.0.0.100
     depends_on:
-      - "db"
+      - 'db'
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - CLIENT_OAUTH_ID=${CLIENT_OAUTH_ID}
@@ -62,9 +62,9 @@ services:
       context: .
       dockerfile: dockerfile_front
     volumes:
-      - "./front:/home/front"
+      - './front:/home/front'
     expose:
-      - "3000"
+      - '3000'
     environment:
       - TZ=Europe/Paris
     networks:
@@ -77,9 +77,9 @@ services:
       context: .
       dockerfile: dockerfile_front
     volumes:
-      - "./front-admin:/home/front"
+      - './front-admin:/home/front'
     expose:
-      - "3000"
+      - '3000'
     environment:
       - TZ=Europe/Paris
     networks:


### PR DESCRIPTION
Cette PR a pour but d'exporter la liste de nos utilisateurs automatiquement vers le serveur du Datalake. Quelques notes techniques permettant de mieux comprendre la PR :
- Un dossier partagé avec le datalake est présent sur notre serveur de prod (`/mnt/datalake/vers_datalake`). Régis l'avait mis en place jadis (et pour les toutes les start-ups)
- Le nom du fichier doit absolument être fixe (le datalake ne gère les noms variables)

La seconde étape consistera à récupérer et traiter le fichier-réponse du datalake mais ça se fera plus tard :smile: 