### PR TITLE
back: prevent crash when trying to skip files

### DIFF
--- a/back/routes/declarations.js
+++ b/back/routes/declarations.js
@@ -395,10 +395,6 @@ router.post('/files', upload.single('document'), (req, res, next) => {
 
       const isAddingFile = !!req.query.add
 
-      const originalFileName = isAddingFile
-        ? declarationInfo.originalFileName
-        : req.file.originalname
-
       let documentFileObj = req.body.skip
         ? {
             // Used in case the user sent his file by another means.
@@ -408,7 +404,9 @@ router.post('/files', upload.single('document'), (req, res, next) => {
           }
         : {
             file: req.file.filename,
-            originalFileName,
+            originalFileName: isAddingFile
+              ? declarationInfo.originalFileName
+              : req.file.originalname,
           }
 
       if (!req.body.skip) {

--- a/back/routes/employers.js
+++ b/back/routes/employers.js
@@ -311,10 +311,6 @@ router.post('/files', upload.single('document'), (req, res, next) => {
         (document) => document.type === type,
       )
 
-      const originalFileName = isAddingFile
-        ? existingDocument.originalFileName
-        : req.file.originalname
-
       let documentFileObj = skip
         ? {
             // Used in case the user sent his file by another means.
@@ -326,7 +322,9 @@ router.post('/files', upload.single('document'), (req, res, next) => {
         : {
             file: req.file.filename,
             type,
-            originalFileName,
+            originalFileName: isAddingFile
+              ? existingDocument.originalFileName
+              : req.file.originalname,
           }
 
       if (!skip) {


### PR DESCRIPTION
Calculer `originalFileName` dans le cas où un document devait être skippé n'a pas de sense et crashait le back.