### PR TITLE
back: add migration script to mark all declarations,  docs until june 2019 as done

### DIFF
--- a/back/migrations/20190925155246_set-all-finished-until-june.js
+++ b/back/migrations/20190925155246_set-all-finished-until-june.js
@@ -1,0 +1,29 @@
+const JUNE_2019_MONTH_ID = 14
+
+exports.up = function(knex, Promise) {
+  return knex.transaction((trx) =>
+    trx
+      .raw(
+        `UPDATE declarations SET "isFinished"=true WHERE "monthId" <= ${JUNE_2019_MONTH_ID} AND "hasFinishedDeclaringEmployers"=true`,
+      )
+      .then(() =>
+        trx
+          .raw(
+            `UPDATE employer_documents SET "isTransmitted"=true WHERE "employerId" IN (
+              SELECT id from employers WHERE "declarationId" IN (
+                SELECT id from declarations WHERE "monthId" <= ${JUNE_2019_MONTH_ID} AND "hasFinishedDeclaringEmployers"=true
+              )
+            )`,
+          )
+          .then(() =>
+            trx.raw(`UPDATE declaration_infos SET "isTransmitted"=true WHERE "declarationId" IN (
+              SELECT id from "declarations" WHERE "monthId" <= ${JUNE_2019_MONTH_ID} AND "hasFinishedDeclaringEmployers"=true
+            )`),
+          ),
+      ),
+  )
+}
+
+exports.down = function(knex, Promise) {
+  return Promise.resolve()
+}


### PR DESCRIPTION
Possibilité également : ajouter une ligne de `employer_documents` vide pour chaque employeur qui n'a pas eu de document associé. Permettrait d'éviter de dépendre à jamais du champ `isFinished` pour l'affichage ou non de documents passés (cf maquettes futures page docs)