### PR TITLE
back: do not attempt token refesrh if no user or no tokenExpirationDate

### DIFF
--- a/back/lib/refreshAccessTokenMiddleware.js
+++ b/back/lib/refreshAccessTokenMiddleware.js
@@ -5,6 +5,8 @@ const {
 } = require('../lib/token')
 
 const refreshAccessToken = (req, res, next) => {
+  if (!req.user || !req.user.tokenExpirationDate) return next()
+
   if (isUserTokenValid(req.user.tokenExpirationDate)) return next()
   if (!isRefreshPossible(req.user.tokenExpirationDate)) return next()
   refreshToken(req).finally(next)


### PR DESCRIPTION
Lors des tests, la session n'a pas de `user.tokenExpirationDate`...