### PR TITLE
back: fix: declaration_months was updated by mistake

### DIFF
--- a/back/lib/declaration.js
+++ b/back/lib/declaration.js
@@ -50,7 +50,7 @@ const fetchDeclarationAndSaveAsFinishedIfAllDocsAreValidated = ({
   userId,
 }) =>
   Declaration.query()
-    .eager(`[declarationMonth, infos, employers.documents]`)
+    .eager(`[infos, employers.documents]`)
     .findOne({
       id: declarationId,
       userId,


### PR DESCRIPTION
The update + problems with UTC caused the declaration_months dates to be moved by 1 day backwards on every update