### PR TITLE
back: export directly in /mnt/datalakepe

### DIFF
--- a/back/lib/exportUserList.js
+++ b/back/lib/exportUserList.js
@@ -6,7 +6,7 @@ const winston = require('../lib/log')
 
 const User = require('../models/User')
 
-const EXPORT_DIR = '/home/back/datalake/versDatalake/'
+const EXPORT_DIR = '/mnt/datalakepe/vers_datalake/'
 const EXPORT_FILENAME_PATH = `${EXPORT_DIR}export_utilisateur.csv`
 const EXPORT_FIELDS = [
   'firstName',

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,8 @@
-version: "2"
+version: '2'
 services:
   node:
     volumes:
-      - "/mnt/datalakepe/vers_datalake/:/home/back/datalake/versDatalake"
+      - '/mnt/datalakepe/:/mnt/datalakepe/'
     environment:
       - NODE_ENV=production
 


### PR DESCRIPTION
Pour que le dossier "/mnt/datalake" (étant un dossier réseau) puisse fonctionner correctement avec le système de volume de Docker, on doit impérativement conserver lié les volumes en conservation le même chemin... et donc faire : `- '/mnt/datalakepe/:/mnt/datalakepe/'`

Il faudra toutefois être vigilant lors de la MEP pour vérifier que tout est ok !