### PR TITLE
front: fix randomly failing e2e tests

### DIFF
--- a/cypress/integration/Actu_spec.js
+++ b/cypress/integration/Actu_spec.js
@@ -6,7 +6,7 @@ import {
   checkFormValues,
   pickDate,
   checkDate,
-  getNextLink,
+  getNextButton,
 } from '../pages/Actu'
 
 const { omit } = Cypress._
@@ -54,10 +54,7 @@ describe('Declaration page', function() {
           const inputsToFill = omit(defaultValues, keyToOmit)
           fillFormAnswers(inputsToFill)
 
-          // cypress yields the label inside the button, so we need to get its parent.
-          getNextLink()
-            .parent('button')
-            .should('be.disabled')
+          getNextButton().should('be.disabled')
 
           cy.reload()
         })
@@ -85,7 +82,7 @@ describe('Declaration page', function() {
               .click()
           }
 
-          getNextLink().click()
+          getNextButton().click()
 
           cy.get('p[role=alert]').should('be.visible')
 
@@ -99,7 +96,7 @@ describe('Declaration page', function() {
             pickDate(fieldToTest, '21')
             pickDate(fieldToTest, '20', { last: true })
 
-            getNextLink().click()
+            getNextButton().click()
 
             cy.get('p[role=alert]')
               .contains('Merci de corriger')
@@ -114,7 +111,7 @@ describe('Declaration page', function() {
     describe('Valid form', () => {
       it('should validate for default declaration', () => {
         fillFormAnswers(defaultValues)
-        getNextLink().click()
+        getNextButton().click()
 
         cy.url().should('contain', '/employers')
 
@@ -150,7 +147,7 @@ describe('Declaration page', function() {
         pickDate('hasInvalidity', '20')
         pickDate('isLookingForJob', '20')
 
-        getNextLink().click()
+        getNextButton().click()
         cy.url().should('contain', '/employers')
 
         // Go back to the page and check that the values in the form are there
@@ -172,7 +169,7 @@ describe('Declaration page', function() {
       it(`should warn the user before transmission if they haven't worked`, () => {
         fillFormAnswers({ ...defaultValues, hasWorked: NO })
         // Open modal
-        getNextLink().click()
+        getNextButton().click()
 
         // Close modal
         cy.get('div[role=dialog] button')
@@ -180,7 +177,7 @@ describe('Declaration page', function() {
           .click()
 
         // Re-open modal
-        getNextLink().click()
+        getNextButton().click()
 
         cy.get('div[role=dialog] button')
           .contains('Oui, je confirme')
@@ -197,7 +194,7 @@ describe('Declaration page', function() {
 
         cy.get('#isLookingForJob').should('not.exist')
 
-        getNextLink().click()
+        getNextButton().click()
         cy.url().should('contain', '/employers')
       })
 
@@ -210,7 +207,7 @@ describe('Declaration page', function() {
         fillFormAnswers(omit(defaultValues, 'hasMaternityLeave'))
         cy.get('#hasMaternityLeave').should('not.exist')
 
-        getNextLink().click()
+        getNextButton().click()
         cy.url().should('contain', '/employers')
       })
     })

--- a/cypress/pages/Actu.js
+++ b/cypress/pages/Actu.js
@@ -42,4 +42,8 @@ export const checkDate = (fieldName, value, { last } = { last: false }) => {
     })
 }
 
-export const getNextLink = () => cy.get('button').contains('Suivant')
+export const getNextButton = () =>
+  cy
+    .get('button')
+    .contains('Suivant')
+    .parent('button')


### PR DESCRIPTION
Un test e2e échoue assez régulièrement et c'est agaçant, ce changement est une tentative de l'éviter, mais forcément faut faire tourner les e2e 5-6 fois pour s'assurer que ça fonctionne bien, donc c'est en cours :)