### PR TITLE
Better use of 'retry-after'

### DIFF
--- a/back/lib/resilientRequest.js
+++ b/back/lib/resilientRequest.js
@@ -48,7 +48,7 @@ const resilientRequest = ({
       throw err
     }
     // HTTP 429 Too many requests
-    return checkHeadersAndWait(err.response.headers).then(() =>
+    return checkHeadersAndWait(err.response.header).then(() =>
       resilientRequest({
         url,
         accessToken,


### PR DESCRIPTION
En regardant l'erreur sur Sentry : https://sentry.io/organizations/zen/issues/1002721483/events/81fb1ae4e071485caa557a9f70e0dd51/?project=1216848

On peut remarquer l'erreur renvoie un objet avec **err.response.header**
Or dans le code, on utilise `err.response.headers` avec un `s` => du coup, cela renvoie un `undefined`
