### PR TITLE
front: fix timezone

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -37,6 +37,7 @@
     "lodash": "^4.17.10",
     "mini-css-extract-plugin": "^0.5.0",
     "moment": "^2.22.2",
+    "moment-timezone": "^0.5.27",
     "object-assign": "4.1.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pnp-webpack-plugin": "^1.2.1",

--- a/front/src/index.js
+++ b/front/src/index.js
@@ -3,7 +3,7 @@ import 'moment/locale/fr'
 
 import CssBaseline from '@material-ui/core/CssBaseline'
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
-import moment from 'moment'
+import moment from 'moment-timezone'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter } from 'react-router-dom'
@@ -31,6 +31,7 @@ if (environment !== 'development') {
 }
 
 moment.locale('fr')
+moment.tz.setDefault('Europe/Paris')
 
 const theme = createMuiTheme({
   typography: {

--- a/front/src/pages/dashboard/DeclarationNotStarted.js
+++ b/front/src/pages/dashboard/DeclarationNotStarted.js
@@ -21,7 +21,13 @@ const DeclarationNotStarted = () => {
     superagent
       .get('/api/declarationMonths/current-declaration-month')
       .then(({ body: { endDate } }) => {
-        setActuEndDate(moment(endDate).format('DD MMMM YYYY'))
+        // Note: the endDate in database is the 16th (at midnight) of the month
+        // So we need to the display the day before as last day for declaration
+        setActuEndDate(
+          moment(endDate)
+            .subtract(1, 'day')
+            .format('DD MMMM YYYY'),
+        )
       })
   }, [])
 

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -8809,7 +8809,14 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.22.2:
+moment-timezone@^0.5.27:
+  version "0.5.27"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.27.tgz#73adec8139b6fe30452e78f210f27b1f346b8877"
+  integrity sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.22.2:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
If the user is not on the same timezone as the server, the date getting from server take the hour diff in account.
Problem: 01/11 00h from the server become 31/10 23h00 after using new Date(). So if we print the current month

To avoid that, we have to fix the timezone on the client side.