### PR TITLE
mail: add infos in declaration queries

### DIFF
--- a/back/lib/mailings/sendDeclarationConfirmationEmails.js
+++ b/back/lib/mailings/sendDeclarationConfirmationEmails.js
@@ -63,7 +63,7 @@ const sendDeclarationConfirmationEmails = () => {
   isSendingEmails = true
 
   return Declaration.query()
-    .eager('[declarationMonth, user, employers]')
+    .eager('[declarationMonth, user, employers, infos]')
     .where({ hasFinishedDeclaringEmployers: true, isEmailSent: false })
     .then((declarations) =>
       Promise.all(


### PR DESCRIPTION
Dans le cas du mail transactionnel, il manquait les infos liés à la candidature.
Du coup, le code : 
```
specialSituations: declaration.infos
      .filter((info) => !['jobSearch'].includes(info.type))
      ...
```
Renvoie : `error: There was an error while sending confirmation email for declaration 24782: TypeError: Cannot read property 'filter' of undefined`