### PR TITLE
secu: can login as user by id (dev only !)

### DIFF
--- a/back/routes/developer.js
+++ b/back/routes/developer.js
@@ -3,6 +3,7 @@
 */
 
 const express = require('express')
+const User = require('../models/User')
 
 const router = express.Router()
 
@@ -15,6 +16,44 @@ router.get('/session/user', (req, res) => {
   }
 
   res.json(req.session.user || {})
+})
+
+/*
+    Security audits will use an URL to access to dev-Zen and can't do any login action.
+    But by doing this, the robot will be always redirecting to the homepage...
+
+    To avoid that, we handle an `connectedAs={ID}` parameter that, if added in the URL,
+    will automatically connect user (with the given ID) and if there is no session yet.
+
+    Ex: http://localhost/api/developer/fake-auth?connectedAs=6687&to=%2Ffiles
+*/
+router.get('/fake-auth', async (req, res) => {
+  if (req.query.connectedAs && !req.session.user) {
+    const connectedAsId = Number(req.query.connectedAs)
+
+    if (!Number.isNaN(connectedAsId)) {
+      const currentId = req.session.user ? req.session.user.id : null
+
+      if (currentId !== connectedAsId) {
+        const user = await User.query().findById(connectedAsId)
+        const { id, firstName, lastName, email, gender } = user
+
+        req.session.user = {
+          id,
+          firstName,
+          lastName,
+          email,
+          gender,
+          isAuthorized: true,
+          canSendDeclaration: true,
+          hasAlreadySentDeclaration: false,
+          tokenExpirationDate: new Date(1654719447626),
+        }
+      }
+    }
+  }
+
+  return res.redirect(req.query.to ? decodeURIComponent(req.query.to) : '/')
 })
 
 router.post('/session/user', (req, res) => {

--- a/back/routes/developer.js
+++ b/back/routes/developer.js
@@ -28,7 +28,7 @@ router.get('/session/user', (req, res) => {
     Ex: http://localhost/api/developer/fake-auth?connectedAs=6687&to=%2Ffiles
 */
 router.get('/fake-auth', async (req, res) => {
-  if (req.query.connectedAs && !req.session.user) {
+  if (req.query.connectedAs) {
     const connectedAsId = Number(req.query.connectedAs)
 
     if (!Number.isNaN(connectedAsId)) {
@@ -36,6 +36,8 @@ router.get('/fake-auth', async (req, res) => {
 
       if (currentId !== connectedAsId) {
         const user = await User.query().findById(connectedAsId)
+        if (!user) return res.send(`User with id ${connectedAsId} not found`)
+
         const { id, firstName, lastName, email, gender } = user
 
         req.session.user = {


### PR DESCRIPTION
Le logiciel d'audits de sécurité n'accepte que des URLs fixes et ne peut donc pas se connecter par lui-même...
Du coup, dans les environnements de développement, on permet de se connecter avec un id avec un paramètre dans l'URL